### PR TITLE
Better Import Management

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,4 +10,5 @@ for blueprint in web_blueprints:
     app.register_blueprint(blueprint)
 
 for blueprint in api_blueprints:
-    app.register_blueprint(blueprint, url_prefix="/api/v1/")
+    app.register_blueprint(
+        blueprint, url_prefix="/api/v1/")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -10,5 +10,4 @@ for blueprint in web_blueprints:
     app.register_blueprint(blueprint)
 
 for blueprint in api_blueprints:
-    app.register_blueprint(
-        blueprint, url_prefix="/api/v1/")
+    app.register_blueprint(blueprint, url_prefix="/api/v1/")

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,20 +1,12 @@
 from pkgutil import iter_modules
 from importlib import import_module
-from os import path as os_path
-from sys import path as sys_path
-
-pwd = os_path.dirname(__file__)
-if pwd not in sys_path:
-    sys_path.append(pwd)
+from os import path
 
 blueprints = []
-for module in iter_modules([pwd]):
-    mod = import_module(name=module.name)
+for module in iter_modules([path.dirname(__file__)]):
+    mod = import_module(name=".%s" % module.name, package=__package__)
 
     for attr in vars(mod):
         value = getattr(mod, attr)
         if type(value).__module__ == "flask.blueprints" and type(value).__name__ == "Blueprint":
             blueprints.append(getattr(mod, attr))
-
-if pwd in sys_path:
-    sys_path.remove(pwd)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, make_response
 
-api = Blueprint('api', __name__)
+api = Blueprint("api", __name__)
 
 
 @api.route('/', methods=['GET'])

--- a/src/web/__init__.py
+++ b/src/web/__init__.py
@@ -1,20 +1,12 @@
 from pkgutil import iter_modules
 from importlib import import_module
-from os import path as os_path
-from sys import path as sys_path
-
-pwd = os_path.dirname(__file__)
-if pwd not in sys_path:
-    sys_path.append(pwd)
+from os import path
 
 blueprints = []
-for module in iter_modules([pwd]):
-    mod = import_module(name=module.name)
+for module in iter_modules([path.dirname(__file__)]):
+    mod = import_module(name=".%s" % module.name, package=__package__)
 
     for attr in vars(mod):
         value = getattr(mod, attr)
         if type(value).__module__ == "flask.blueprints" and type(value).__name__ == "Blueprint":
             blueprints.append(getattr(mod, attr))
-
-if pwd in sys_path:
-    sys_path.remove(pwd)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, make_response, render_template
 
-web = Blueprint('web', __name__, template_folder='templates')
+web = Blueprint("web", __name__, template_folder='templates')
 
 
 @web.route('/', methods=['GET'])


### PR DESCRIPTION
The `__init__` files grab Flask blueprints from the modules in their current directory. Before, there was an issue with `web` and `api` having modules by the same name. There was also `sys.path` stuff happening to make the imports happening, which was a hack. This fixes that.